### PR TITLE
Implemented player boosts

### DIFF
--- a/Assets/ScriptableObjects/Items/TestItems/DiamondAxe.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/DiamondAxe.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 4a676a7b6d9694141aa62eb3fcacbf23, type: 3}
   durability: 100
   durabilityDecreasePerUse: 3
+  damagePerAttack: 10
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 2
   itemID: 467324770
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/DiamondHoe.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/DiamondHoe.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 7653b3628933ba54e848f65db4d043b2, type: 3}
   durability: 100
   durabilityDecreasePerUse: 3
+  damagePerAttack: 4
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 2
   itemID: 399972954
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/DiamondPickaxe.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/DiamondPickaxe.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 9e0805c57eaf46f4ba59a0ae4b2b59b6, type: 3}
   durability: 100
   durabilityDecreasePerUse: 2
+  damagePerAttack: 6
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 2
   itemID: 139553628
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/DiamondShovel.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/DiamondShovel.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 441279047eafbab43bba7de3a5f26c89, type: 3}
   durability: 100
   durabilityDecreasePerUse: 3
+  damagePerAttack: 2
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 2
   itemID: 46603575
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/DiamondSword.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/DiamondSword.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 14cf00dcf25942e438760fdd831c2ad0, type: 3}
   durability: 100
   durabilityDecreasePerUse: 3
+  damagePerAttack: 25
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 2
   itemID: 244407929
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/NetheriteBoots.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/NetheriteBoots.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 9c4d1d4aa84595f4e8c459b212c2ce85, type: 3}
   durability: 100
   durabilityDecreasePerUse: 2
+  damagePerAttack: 0
+  oxygenBoost: 0
+  healthBoost: 5
+  speedBoost: 5
   type: 3
   itemID: 35962732
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/NetheriteChestplate.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/NetheriteChestplate.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: b658bc0c7e2368949a4ce8d7a06e67bb, type: 3}
   durability: 100
   durabilityDecreasePerUse: 2
+  damagePerAttack: 0
+  oxygenBoost: 0
+  healthBoost: 50
+  speedBoost: 0
   type: 3
   itemID: 897005225
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/NetheriteHelmet.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/NetheriteHelmet.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: e0ddf69ed03311b46ae32c8fea60acec, type: 3}
   durability: 100
   durabilityDecreasePerUse: 2
+  damagePerAttack: 0
+  oxygenBoost: 50
+  healthBoost: 10
+  speedBoost: 0
   type: 3
   itemID: 994147248
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/NetheriteLeggings.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/NetheriteLeggings.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: d1850d2c0409ce44ca8703fc3ebd8a95, type: 3}
   durability: 100
   durabilityDecreasePerUse: 2
+  damagePerAttack: 0
+  oxygenBoost: 0
+  healthBoost: 15
+  speedBoost: 0
   type: 3
   itemID: 165112956
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/StoneAxe.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/StoneAxe.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 520483d79daca2941acb1732bb6af6ed, type: 3}
   durability: 100
   durabilityDecreasePerUse: 2
+  damagePerAttack: 5
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 0
   itemID: 10539724
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/StoneHoe.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/StoneHoe.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 28c609a6b6624a844a593fd8059eb1bb, type: 3}
   durability: 100
   durabilityDecreasePerUse: 2
+  damagePerAttack: 2
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 0
   itemID: 278630102
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/StonePickaxe.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/StonePickaxe.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 3b344e148b0f2c1418123db996ec1875, type: 3}
   durability: 100
   durabilityDecreasePerUse: 2
+  damagePerAttack: 3
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 0
   itemID: 688631758
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/StoneShovel.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/StoneShovel.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 9ddb40c03d8e51245a1b134133829b84, type: 3}
   durability: 100
   durabilityDecreasePerUse: 2
+  damagePerAttack: 1
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 0
   itemID: 742940431
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/StoneSword.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/StoneSword.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: a6a54a25692b0d748866959e16e9b255, type: 3}
   durability: 100
   durabilityDecreasePerUse: 2
+  damagePerAttack: 10
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 0
   itemID: 578475221
   isStackable: 0

--- a/Assets/ScriptableObjects/Items/TestItems/TNT.asset
+++ b/Assets/ScriptableObjects/Items/TestItems/TNT.asset
@@ -17,6 +17,10 @@ MonoBehaviour:
   itemSprite: {fileID: 21300000, guid: 036d6ebe2b05d5743b35cbd682362b15, type: 3}
   durability: 100
   durabilityDecreasePerUse: 1
+  damagePerAttack: 15
+  oxygenBoost: 0
+  healthBoost: 0
+  speedBoost: 0
   type: 0
   itemID: 435609102
   isStackable: 1

--- a/Assets/Scripts/HealthBar.cs
+++ b/Assets/Scripts/HealthBar.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -5,12 +6,18 @@ using UnityEngine.UI;
 
 public class HealthBar : MonoBehaviour
 {
-
+    public static HealthBar instance;
     public Slider healthSlider;
     public Slider damageHealthSlider;
     public float maxHealth = 100f;
     public float health;
     private float lerpSpeed = 0.1f;
+
+    // Awake is called when the script instance is being loaded
+    private void Awake()
+    {
+        instance = this;
+    }
 
     // Start is called before the first frame update
     void Start()
@@ -29,6 +36,16 @@ public class HealthBar : MonoBehaviour
         if (healthSlider.value != damageHealthSlider.value)
         {
             damageHealthSlider.value = Mathf.Lerp(damageHealthSlider.value, health, lerpSpeed);
+        }
+    }
+
+    public void ChangeHealth(int val)
+    {
+        maxHealth += val;
+
+        if (val < 0)
+        {
+            health = Math.Min(health, maxHealth);
         }
     }
 

--- a/Assets/Scripts/InventorySystem/InventoryBackgroundDropItem.cs
+++ b/Assets/Scripts/InventorySystem/InventoryBackgroundDropItem.cs
@@ -5,15 +5,27 @@ using UnityEngine.EventSystems;
 
 public class InventoryBackgroundDropItem : MonoBehaviour, IDropHandler
 {
+    // Variables
+    [SerializeField] private GameObject itemDropperPrefab;
+
+    /// <summary>
+    /// Removes the item from the player and unequips it if it's equipped.
+    /// </summary>
+    /// <param name="eventData"></param>
     public void OnDrop(PointerEventData eventData)
     {
         InventoryItem draggableItem = eventData.pointerDrag.GetComponent<InventoryItem>();
 
-        // Drop item and remove it from the inventory
-        Debug.Log("Dropped " + draggableItem.currentStackSize + " " + draggableItem.storedItem.itemName);
+        // Unequip the item if it's equipped
+        if (draggableItem.equipped)
+        {
+            InventoryManager.instance.UnequipItem(draggableItem.storedItem);
+        }
 
-        // Most likely give the dropped item to some other game object here before destroying it
+        // Drop the item
+        //TODO: This is where the item is dropped
 
+        // Destroy the object
         Destroy(draggableItem.gameObject);
     }
 }

--- a/Assets/Scripts/InventorySystem/InventoryManager.cs
+++ b/Assets/Scripts/InventorySystem/InventoryManager.cs
@@ -383,6 +383,8 @@ public class InventoryManager : MonoBehaviour
     /// </summary>
     public void SortInventory()
     {
+        HealthBar.instance.TakeDamage(25);
+
         // Sort the items
         Dictionary<Item, int> items = new();
 
@@ -418,34 +420,40 @@ public class InventoryManager : MonoBehaviour
         }
     }
 
-    // Adds the power-ups from the given item
+    /// <summary>
+    /// Adds the boosts of the given item from the player.
+    /// </summary>
+    /// <param name="item">The Item object that should be checked for boosts.</param>
     public void EquipItem(Item item)
     {
         // Add the oxygen boost
-        
+        PlayerMovementAndOxygen.instance.ChangeOxygen(item.oxygenBoost);
 
         // Add the health boost
-        
+        HealthBar.instance.ChangeHealth(item.healthBoost);
 
         // Add the speed boost
-        
-    }
-
-    // Removes the power-ups from the given item
-    public void UnequipItem(Item item)
-    {
-        // Remove the oxygen boost
-        
-
-        // Remove the health boost
-        
-
-        // Remove the speed boost
-        
+        PlayerMovementAndOxygen.instance.ChangeMoveSpeed(item.speedBoost);
     }
 
     /// <summary>
-    /// Removes all power-ups that were equipped.
+    /// Removes the boosts of the given item from the player.
+    /// </summary>
+    /// <param name="item">The Item object that should be checked for boosts.</param>
+    public void UnequipItem(Item item)
+    {
+        // Remove the oxygen boost
+        PlayerMovementAndOxygen.instance.ChangeOxygen(-item.oxygenBoost);
+
+        // Remove the health boost
+        HealthBar.instance.ChangeHealth(-item.healthBoost);
+
+        // Remove the speed boost
+        PlayerMovementAndOxygen.instance.ChangeMoveSpeed(-item.speedBoost);
+    }
+
+    /// <summary>
+    /// Removes all power-ups that were equipped from the player.
     /// </summary>
     public void UnequipAllItems()
     {

--- a/Assets/Scripts/InventorySystem/InventorySlotHolder.cs
+++ b/Assets/Scripts/InventorySystem/InventorySlotHolder.cs
@@ -170,8 +170,6 @@ public class InventorySlotHolder : MonoBehaviour, IDropHandler
 
         InventoryManager.instance.EquipItem(item);
         EquipSlot();
-
-        Debug.Log(GetStoredItem().itemName + " has been equipped!");
     }
 
     /// <summary>
@@ -183,16 +181,17 @@ public class InventorySlotHolder : MonoBehaviour, IDropHandler
 
         if (storedItem != null && storedItem.type == ItemType.Armour)
         {
-            // Change equip status to false
-            GetComponentInChildren<InventoryItem>().equipped = false;
+            if (GetComponentInChildren<InventoryItem>().equipped == true)
+            {
+                // Change equip status to false
+                GetComponentInChildren<InventoryItem>().equipped = false;
 
-            // Get stored item in InventoryItem
-            Item item = GetComponentInChildren<InventoryItem>().storedItem;
+                // Get stored item in InventoryItem
+                Item item = GetComponentInChildren<InventoryItem>().storedItem;
 
-            InventoryManager.instance.UnequipItem(item);
-            UnequipSlot();
-
-            Debug.Log(storedItem.itemName + " has been unequipped!");
+                InventoryManager.instance.UnequipItem(item);
+                UnequipSlot();
+            }
         }
     }
 

--- a/Assets/Scripts/InventorySystem/Item.cs
+++ b/Assets/Scripts/InventorySystem/Item.cs
@@ -25,21 +25,28 @@ public class Item : ScriptableObject
 
     [Header("Not visible to players")]
     
-    [Range(1, 100)]
-    [Tooltip("The amount of durability that is decreased per use. This vaule should be between 1 and 100 inclusive.")]
-    public int durabilityDecreasePerUse;
+    [Range(0, 100)]
+    [Tooltip("The amount of durability that is decreased per use. This vaule should be between 0 and 100 inclusive.")]
+    public int durabilityDecreasePerUse = 0;
 
-    [Tooltip("The boost to the player's oxygen meter.")]
+    [Range(0, 100)]
+    [Tooltip("The damage dealt to the enemy per hit. This vaule should be between 0 and 100 inclusive.")]
+    public int damagePerAttack = 0;
+
+    [Range(0, 100)]
+    [Tooltip("The boost to the player's oxygen meter. This vaule should be between 0 and 100 inclusive.")]
     public int oxygenBoost = 0;
 
-    [Tooltip("The boost to the player's health meter.")]
+    [Range(0, 100)]
+    [Tooltip("The boost to the player's health meter. This vaule should be between 0 and 100 inclusive.")]
     public int healthBoost = 0;
 
-    [Tooltip("The boost to the player's swim speed.")]
+    [Range(0, 25)]
+    [Tooltip("The boost to the player's swim speed. This vaule should be between 0 and 25 inclusive.")]
     public int speedBoost = 0;
 
     [Tooltip("The type of the item.")]
-    public ItemType type;
+    public ItemType type = ItemType.Others;
     
     [Tooltip("The ID of the item. This must be unique to each item.")]
     [ContextMenuItem("Generate a random ID", "GenerateItemID")]
@@ -62,7 +69,7 @@ public class Item : ScriptableObject
 
 public enum ItemType
 {
-    Others,         // Others is the default item type, so don't remove it.
+    Others,         // Others is the default item type.
     Consumable,     // Consumables would usually have a durabilityDecreasePerUse of 100.
     Weapon,         // Weapons would usually have a durabilityDecreasePerUse of 1 or lower and not be stackable.
     Armour          // Armour would usually not be stackable.

--- a/Assets/Scripts/PlayerMovementAndOxygen.cs
+++ b/Assets/Scripts/PlayerMovementAndOxygen.cs
@@ -5,8 +5,10 @@ using UnityEngine;
 using UnityEngine.Serialization;
 using UnityEngine.UI;
 
-public class playerMovement : MonoBehaviour {
-    //Variables
+public class PlayerMovementAndOxygen : MonoBehaviour {
+    // Variables
+    public static PlayerMovementAndOxygen instance;
+ 
     public float moveSpeed = 5f;
     public Rigidbody2D rigidBody;
     public GameObject seaLineObject; // should be a thin object with a boxCollider2D component and trigger enabled
@@ -18,6 +20,8 @@ public class playerMovement : MonoBehaviour {
     private bool canMoveUp = true;
 
     public GameObject oxygenSlider;
+
+    private float maxOxygen = 100.0f;
 
     private float oxygen = 100.0f;
 
@@ -40,6 +44,11 @@ public class playerMovement : MonoBehaviour {
     public HealthBar playerHealth;
     private int drownTimer = 0;
 
+    // Awake is called when the script instance is being loaded
+    private void Awake()
+    {
+        instance = this;
+    }
 
     void Start() {
         Physics2D.IgnoreCollision(seaTopBoxCollider, playerCollider, true);
@@ -55,7 +64,7 @@ public class playerMovement : MonoBehaviour {
             oxygenSlider.GetComponent<Slider>().value = oxygen*0.01f;
         }
 
-        else if (oxygen < 100.0f && canBreath) {
+        else if (oxygen < maxOxygen && canBreath) {
             oxygen += 10*oxygenGainRate * Time.deltaTime;
             oxygenSlider.GetComponent<Slider>().value = oxygen*0.01f;
         }
@@ -96,6 +105,21 @@ public class playerMovement : MonoBehaviour {
         else v = new Vector2(movement.x, 0);
 
         rigidBody.AddForce(v.normalized * moveSpeed);
+    }
+
+    public void ChangeOxygen(int val)
+    {
+        maxOxygen += val;
+
+        if (val < 0)
+        {
+            oxygen = Math.Min(oxygen, maxOxygen);
+        }
+    }
+
+    public void ChangeMoveSpeed(int val)
+    {
+        moveSpeed += val;
     }
 
     void OnTriggerExit2D(Collider2D other) {


### PR DESCRIPTION
## Changed
- All items now have a `damagePerAttack`, `oxygenBoost`, `healthBoost`, and `speedBoost` value.
- Changed the _HealthBar_ and _PlayerMovementAndOxygen_ scripts to create an instance to access it easier in other scripts.
- Added functions to change the health, speed, and oxygen values.
- Items now unequip when dropped outside the inventory.
- `UnequipItem` now checks if the item was previously equipped before unequipping it.
- Added some default values to the _Item_ objects.