### PR TITLE
low-oxygen-and-health-feedback

### DIFF
--- a/Assets/Objects/Items/Trinkets/BeanBuddy.asset.meta
+++ b/Assets/Objects/Items/Trinkets/BeanBuddy.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 754cf3c92aa457a40bec506338fc36b0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Objects/Items/Trinkets/NeedleGreenWhole.asset.meta
+++ b/Assets/Objects/Items/Trinkets/NeedleGreenWhole.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ddd133a7e832ad24580861c90293ea5b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Objects/Items/Weapons/Bananarang.asset.meta
+++ b/Assets/Objects/Items/Weapons/Bananarang.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7019325cb26f6c4468deea7a0270dfef
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Objects/Items/Weapons/Halo.asset.meta
+++ b/Assets/Objects/Items/Weapons/Halo.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 679f1910cfa16ae46be66453d30c354d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Objects/Items/Weapons/JestersFeast.asset.meta
+++ b/Assets/Objects/Items/Weapons/JestersFeast.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 605b95b9344d4474c8d388ea48d9613a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Objects/Items/Weapons/NeedlePurpleWhole.asset.meta
+++ b/Assets/Objects/Items/Weapons/NeedlePurpleWhole.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 85c9b069f3562784ab8a82ee4b7d40ea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/BossHealthBar.prefab
+++ b/Assets/Prefabs/BossHealthBar.prefab
@@ -226,13 +226,60 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 3152073911118305300, guid: d94570814cc34b549adcc3e0dfd68914, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7057883240663469768, guid: d94570814cc34b549adcc3e0dfd68914, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1669428915196703386}
   m_SourcePrefab: {fileID: 100100000, guid: d94570814cc34b549adcc3e0dfd68914, type: 3}
+--- !u!1 &699838698549553798 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7057883240663469768, guid: d94570814cc34b549adcc3e0dfd68914, type: 3}
+  m_PrefabInstance: {fileID: 7513395058028307534}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1669428915196703386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 699838698549553798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bce48520fee13945a32af0bf42deacb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healthSlider: {fileID: 6512777829341606789}
+  damageSlider: {fileID: 6080675409421511023}
+  maxHealth: 500
+  lowHealth: 0.2
 --- !u!224 &1122647125229027899 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7480621245974718069, guid: d94570814cc34b549adcc3e0dfd68914, type: 3}
   m_PrefabInstance: {fileID: 7513395058028307534}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6080675409421511023 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4334176903116508449, guid: d94570814cc34b549adcc3e0dfd68914, type: 3}
+  m_PrefabInstance: {fileID: 7513395058028307534}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6512777829341606789 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3613848509754759115, guid: d94570814cc34b549adcc3e0dfd68914, type: 3}
+  m_PrefabInstance: {fileID: 7513395058028307534}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/PlayerHealthBar.prefab
+++ b/Assets/Prefabs/PlayerHealthBar.prefab
@@ -118,6 +118,10 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 70758547245525246, guid: bee921ffe10654268bf231705b99b023, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 166108747890924356, guid: bee921ffe10654268bf231705b99b023, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -202,6 +206,34 @@ PrefabInstance:
       propertyPath: m_Name
       value: PlayerHealthManager
       objectReference: {fileID: 0}
+    - target: {fileID: 454006322416594559, guid: bee921ffe10654268bf231705b99b023, type: 3}
+      propertyPath: lowOxygen
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 454006322416594559, guid: bee921ffe10654268bf231705b99b023, type: 3}
+      propertyPath: shakeAmount
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 454006322416594559, guid: bee921ffe10654268bf231705b99b023, type: 3}
+      propertyPath: oxygenSlider
+      value: 
+      objectReference: {fileID: 8149892018421492186}
+    - target: {fileID: 1966520745160303653, guid: bee921ffe10654268bf231705b99b023, type: 3}
+      propertyPath: m_Value
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 1966520745160303653, guid: bee921ffe10654268bf231705b99b023, type: 3}
+      propertyPath: m_MaxValue
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3315748878974305468, guid: bee921ffe10654268bf231705b99b023, type: 3}
+      propertyPath: lowHealth
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 3315748878974305468, guid: bee921ffe10654268bf231705b99b023, type: 3}
+      propertyPath: shakeAmount
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 6305080672677362126, guid: bee921ffe10654268bf231705b99b023, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -228,3 +260,14 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 166108747890924356, guid: bee921ffe10654268bf231705b99b023, type: 3}
   m_PrefabInstance: {fileID: 7660701780979387903}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8149892018421492186 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1966520745160303653, guid: bee921ffe10654268bf231705b99b023, type: 3}
+  m_PrefabInstance: {fileID: 7660701780979387903}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/BossLevel.unity
+++ b/Assets/Scenes/BossLevel.unity
@@ -1531,13 +1531,13 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 2d46e6d47647190468e1eb6fe15135cf, type: 3}
 --- !u!114 &2323811412639445807 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4898397397572942938, guid: 2d46e6d47647190468e1eb6fe15135cf, type: 3}
+  m_CorrespondingSourceObject: {fileID: 1669428915196703386, guid: 2d46e6d47647190468e1eb6fe15135cf, type: 3}
   m_PrefabInstance: {fileID: 2323811412639445806}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 45d264047ce5453459ca9e19ba0f271a, type: 3}
+  m_Script: {fileID: 11500000, guid: 4bce48520fee13945a32af0bf42deacb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807

--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -1799,7 +1799,7 @@ PrefabInstance:
     - target: {fileID: 1536919061356436556, guid: bb95059c729f24ff9a8605c2c03ceb9a, type: 3}
       propertyPath: oxygenSlider
       value: 
-      objectReference: {fileID: 1015333837}
+      objectReference: {fileID: 0}
     - target: {fileID: 1536919061356436556, guid: bb95059c729f24ff9a8605c2c03ceb9a, type: 3}
       propertyPath: playerHealth
       value: 

--- a/Assets/Scripts/Boss/BossSlide.cs
+++ b/Assets/Scripts/Boss/BossSlide.cs
@@ -12,7 +12,7 @@ public class BossSlide : MonoBehaviour
 {
     public static BossSlide instance;
     public float health = 500.0f;
-    public EnemyHealthBar bossHealth;
+    public BossHealthBar bossHealth;
     private Rigidbody2D rb;
     private Vector3 StartPosition;
     private float DistanceOut = 22;

--- a/Assets/Scripts/InventorySystem/InventoryManager.cs
+++ b/Assets/Scripts/InventorySystem/InventoryManager.cs
@@ -276,7 +276,7 @@ public class InventoryManager : MonoBehaviour
         }
 
         // Remove the oxygen boost
-        OxygenBar.instance.ChangeOxygen(item.oxygenBoost);
+        OxygenBar.instance.ChangeMaxOxygen(item.oxygenBoost);
 
         // Remove the health boost
         PlayerHealthBar.instance.ChangeMaxHealth(item.healthBoost);
@@ -301,7 +301,7 @@ public class InventoryManager : MonoBehaviour
         }
 
         // Remove the oxygen boost
-        OxygenBar.instance.ChangeOxygen(-item.oxygenBoost);
+        OxygenBar.instance.ChangeMaxOxygen(-item.oxygenBoost);
 
         // Remove the health boost
         PlayerHealthBar.instance.ChangeMaxHealth(-item.healthBoost);

--- a/Assets/Scripts/Player Movement/PlayerMovement.cs
+++ b/Assets/Scripts/Player Movement/PlayerMovement.cs
@@ -231,4 +231,10 @@ public class PlayerMovement : MonoBehaviour
             Physics2D.IgnoreCollision(seaTopBoxCollider, playerCollider, true);
         }
     }
+
+    // Getters and setters
+    public bool isInSea()
+    {
+        return inSea;
+    }
 }

--- a/Assets/Scripts/UI/HealthBars/BossHealthBar.cs
+++ b/Assets/Scripts/UI/HealthBars/BossHealthBar.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+public class BossHealthBar : HealthBar
+{
+    // Variables
+    protected bool shake = false;
+    protected Vector3 barPosition;
+    [SerializeField] protected float lowHealth;
+
+    private new void Start()
+    {
+        base.Start();
+        barPosition = healthSlider.transform.localPosition;
+    }
+
+    /// <summary>
+    /// Check if the boss is at low health.
+    /// </summary>
+    private new void Update()
+    {
+        base.Update();
+
+        if (health / maxHealth < lowHealth)
+        {
+            shake = true;
+        }
+        else if (shake)
+        {
+            shake = false;
+        }
+    }
+
+    /// <summary>
+    /// Shake the health bar when the player's health is low.
+    /// </summary>
+    private void FixedUpdate()
+    {
+        if (barPosition != new Vector3())
+        {
+            if (shake)
+            {
+                healthSlider.transform.localPosition = new Vector3(UnityEngine.Random.Range(-5, 5), UnityEngine.Random.Range(-5, 5), 0);
+                damageSlider.transform.localPosition = new Vector3(UnityEngine.Random.Range(-5, 5), UnityEngine.Random.Range(-5, 5), 0);
+            }
+            else
+            {
+                healthSlider.transform.localPosition = barPosition;
+                damageSlider.transform.localPosition = barPosition;
+            }
+        }
+    }
+
+    public new void TakeDamage(int damage)
+    {
+        base.TakeDamage(damage);
+    }
+}

--- a/Assets/Scripts/UI/HealthBars/BossHealthBar.cs.meta
+++ b/Assets/Scripts/UI/HealthBars/BossHealthBar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4bce48520fee13945a32af0bf42deacb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/HealthBars/HealthBar.cs
+++ b/Assets/Scripts/UI/HealthBars/HealthBar.cs
@@ -19,19 +19,22 @@ public class HealthBar : MonoBehaviour
     /// <summary>
     /// Sets the health to the max health when the game starts.
     /// </summary>
-    void Start()
+    protected void Start()
     {
         health = maxHealth;
+
+        healthSlider.value = health;
+        damageSlider.value = health;
     }
 
     /// <summary>
     /// Updates the health bar to reflect the current health of the player.
     /// </summary>
-    void Update()
+    protected void Update()
     {
         if (healthSlider.value != health)
         {
-            healthSlider.value = health;
+            healthSlider.value = Mathf.Lerp(healthSlider.value, health, lerpSpeed * 2);
         }
 
         if (healthSlider.value != damageSlider.value)

--- a/Assets/Scripts/UI/HealthBars/PlayerHealthBar.cs
+++ b/Assets/Scripts/UI/HealthBars/PlayerHealthBar.cs
@@ -12,18 +12,67 @@ public class PlayerHealthBar : HealthBar
 
     private bool isMaxHealth = true;
     private bool gameOver = false;
+    protected bool shake = false;
 
     private float healthBarRatio;
+    protected Vector3 barPosition;
+    [SerializeField] protected float lowHealth;
+    [SerializeField] private int shakeAmount = 3;
 
+    /// <summary>
+    /// Creates a singleton instance of the PlayerHealthBar.
+    /// </summary>
     private void Awake()
     {
         instance = this;
     }
 
-    void Start()
+    /// <summary>
+    /// Sets the health to the max health when the game starts.
+    /// </summary>
+    private new void Start()
     {
+        base.Start();
+
         healthBarRatio = healthSlider.transform.localScale.x / maxHealth;
-        health = maxHealth;
+        barPosition = healthSlider.transform.localPosition;
+    }
+
+    /// <summary>
+    /// Check if the player is at low health
+    /// </summary>
+    private new void Update()
+    {
+        base.Update();
+
+        if (health / maxHealth < lowHealth)
+        {
+            shake = true;
+        }
+        else if (shake)
+        {
+            shake = false;
+        }
+    }
+
+    /// <summary>
+    /// Shake the health bar when the player's health is low.
+    /// </summary>
+    private void FixedUpdate()
+    {
+        if (barPosition != new Vector3())
+        {
+            if (shake)
+            {
+                healthSlider.transform.localPosition = new Vector3(barPosition.x + UnityEngine.Random.Range(-shakeAmount, shakeAmount), barPosition.y + UnityEngine.Random.Range(-shakeAmount, shakeAmount), barPosition.z);
+                damageSlider.transform.localPosition = new Vector3(barPosition.x + UnityEngine.Random.Range(-shakeAmount, shakeAmount), barPosition.y + UnityEngine.Random.Range(-shakeAmount, shakeAmount), barPosition.z);
+            }
+            else
+            {
+                healthSlider.transform.localPosition = barPosition;
+                damageSlider.transform.localPosition = barPosition;
+            }
+        }
     }
 
     /// <summary>
@@ -42,7 +91,10 @@ public class PlayerHealthBar : HealthBar
         }
     }
 
-    // Changes the max health of the player by the given value. Can be either negative or positive. This value also changes the current health of the player to be in the range of [0, maxHealth].
+    /// <summary>
+    /// Changes the max health of the player by the given value. Can be either negative or positive. This value also changes the current health of the player to be in the range of [0, maxHealth].
+    /// </summary>
+    /// <param name="val">The value to change the maxHealth variable by.</param>
     public new void ChangeMaxHealth(int val)
     {
         maxHealth += val;
@@ -73,6 +125,9 @@ public class PlayerHealthBar : HealthBar
         }
     }
 
+    /// <summary>
+    /// Change the size of the health bar.
+    /// </summary>
     public void ChangeHealthBarSize()
     {
         healthSlider.transform.localScale = new Vector3(healthBarRatio * maxHealth, healthSlider.transform.localScale.y, healthSlider.transform.localScale.z);

--- a/Assets/Scripts/UI/OxygenBar.cs
+++ b/Assets/Scripts/UI/OxygenBar.cs
@@ -9,15 +9,23 @@ public class OxygenBar : MonoBehaviour
     // Variables
     public static OxygenBar instance;
 
-    [SerializeField] protected GameObject oxygenSlider;
+    [SerializeField] protected Slider oxygenSlider;
 
     private bool canBreath = true;
-    private float oxygen = 100.0f;
+    private float oxygen;
     [SerializeField] private float maxOxygen = 100.0f;
-    [SerializeField] protected float oxygenChangeRate = 1.0f;
+    [SerializeField] protected int oxygenGainRate = 2;
+    [SerializeField] protected int oxygenDepletionRate = 1;
+    [SerializeField] protected float lowOxygen;
     [SerializeField] private int oxygenDamage = 3;
     [SerializeField] private int drownTimer = 100;
     private int currentDrownTimer = 0;
+
+    private bool isMaxOxygen = true;
+    private float oxygenBarRatio;
+    protected Vector3 barPosition;
+    private bool shake = false;
+    [SerializeField] private int shakeAmount = 3;
 
     /// <summary>
     /// Creates a singleton instance of the OxygenBar.
@@ -28,19 +36,31 @@ public class OxygenBar : MonoBehaviour
     }
 
     /// <summary>
+    /// Sets the oxygen level to the max oxygen level when the game starts.
+    /// </summary>
+    private void Start()
+    {
+        oxygen = maxOxygen;
+        oxygenSlider.value = oxygen;
+
+        oxygenBarRatio = oxygenSlider.transform.localScale.x / maxOxygen;
+        barPosition = oxygenSlider.transform.localPosition;
+    }
+
+    /// <summary>
     /// Decreases the oxygen level of the player if the player is not able to breathe. Otherwise, increases the oxygen level of the player.
     /// </summary>
     void Update()
     {
         if (oxygen > 0.0f && !canBreath)
         {
-            oxygen -= oxygenChangeRate * Time.deltaTime;
-            oxygenSlider.GetComponent<Slider>().value = oxygen * 0.01f;
+            oxygen -= oxygenDepletionRate * Time.deltaTime;
+            oxygenSlider.value = oxygen;
         }
         else if (oxygen < maxOxygen && canBreath)
         {
-            oxygen += 10 * oxygenChangeRate * Time.deltaTime;
-            oxygenSlider.GetComponent<Slider>().value = oxygen * 0.01f;
+            oxygen += oxygenGainRate * Time.deltaTime;
+            oxygenSlider.value = oxygen;
         }
 
         if (oxygen <= 0.0f)
@@ -52,6 +72,54 @@ public class OxygenBar : MonoBehaviour
             }
             currentDrownTimer++;
         }
+
+        if (oxygen / maxOxygen < lowOxygen)
+        {
+            shake = true;
+        }
+        else if (shake)
+        {
+            shake = false;
+        }
+    }
+
+    /// <summary>
+    /// Shake the health bar when the player's health is low.
+    /// </summary>
+    private void FixedUpdate()
+    {
+        if (barPosition != new Vector3())
+        {
+            if (shake)
+            {
+                oxygenSlider.transform.localPosition = new Vector3(barPosition.x + UnityEngine.Random.Range(-shakeAmount, shakeAmount), barPosition.y + UnityEngine.Random.Range(-shakeAmount, shakeAmount), barPosition.z);
+            }
+            else
+            {
+                oxygenSlider.transform.localPosition = barPosition;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Changes the max oxygen of the player by the given value. Can be either negative or positive. This value also changes the current oxygen of the player to be in the range of [0, maxOxygen].
+    /// </summary>
+    /// <param name="val">The value to change the maxOxygen variable by.</param>
+    public void ChangeMaxOxygen(int val)
+    {
+        maxOxygen += val;
+
+        if (isMaxOxygen)
+        {
+            oxygen = maxOxygen;
+        }
+        else
+        {
+            oxygen = Math.Min(oxygen, maxOxygen);
+            oxygen += val;
+        }
+
+        ChangeOxygenBarSize();
     }
 
     /// <summary>
@@ -66,6 +134,15 @@ public class OxygenBar : MonoBehaviour
         {
             oxygen = Math.Min(oxygen, maxOxygen);
         }
+    }
+
+    /// <summary>
+    /// Change the size of the oxygen bar.
+    /// </summary>
+    public void ChangeOxygenBarSize()
+    {
+        oxygenSlider.transform.localScale = new Vector3(oxygenBarRatio * maxOxygen, oxygenSlider.transform.localScale.y, oxygenSlider.transform.localScale.z);
+        oxygenSlider.maxValue = maxOxygen;
     }
 
     /// <summary>

--- a/Assets/Scripts/WeaponAttacks/WeaponManager.cs
+++ b/Assets/Scripts/WeaponAttacks/WeaponManager.cs
@@ -9,7 +9,6 @@ public class WeaponManager : MonoBehaviour
     public GameObject BananarangObject;
     public GameObject[] BananarangClones;
     private Transform PlayerTransform;
-    private Transform SealineTransform;
     private Vector3 BananarangPosition;
     private Vector3 Direction;
     private Vector3 MousePosition;
@@ -24,7 +23,6 @@ public class WeaponManager : MonoBehaviour
     void Start()
     {
         MainCamera = GameObject.FindGameObjectWithTag("MainCamera").GetComponent<Camera>();
-        SealineTransform = GameObject.FindGameObjectWithTag("Sealine").GetComponent<Transform>();
         BananarangReady = true;
         BananarangCount = 3;
     }
@@ -48,7 +46,7 @@ public class WeaponManager : MonoBehaviour
             }
         }
 
-        if (PlayerTransform.position.y < SealineTransform.position.y)
+        if (PlayerMovement.instance.isInSea())
         {
             if (BananarangReady)
             {


### PR DESCRIPTION
- Added item meta files for some custom items. (not sure why it had to do that)
- Fixed small bugs that were occurring in other parts of the code.
- Made small quality-of-life improvements to visual aspects of the UI.
- Added feedback for when the oxygen or health bar gets below a certain amount. (this works when there's a trinket involved)
- The player can now gain oxygen (and increase their max oxygen capacity) when a trinket with an oxygen boost is used.